### PR TITLE
Add gzip support to bumblebee

### DIFF
--- a/bumble-bee/bumble-bee.py
+++ b/bumble-bee/bumble-bee.py
@@ -25,6 +25,8 @@ import yaml
 import urllib2
 from urllib2 import Request, urlopen, URLError, HTTPError
 import re
+import gzip
+from StringIO import StringIO
 import HTMLParser
 import BeautifulSoup
 import operator
@@ -131,7 +133,12 @@ class BumbleBee(ApiaryBot):
             f, duration = self.make_request(site,data_url)
             if f is not None:
                 # Create an object that is the same as that returned by the API
-                ret_string = f.read()
+                if f.info().get('Content-Encoding') == 'gzip':
+                    buf = StringIO(f.read())
+                    gz = gzip.GzipFile(fileobj=buf)
+                    ret_string = gz.read()
+                else:
+                    ret_string = f.read()
                 ret_string = ret_string.strip()
                 if re.match(r'(\w+=\d+)\;?', ret_string):
                     # The return value looks as we expected


### PR DESCRIPTION
This pull request is made after we messaged @kghbln here: https://www.wikiapiary.com/wiki/User_talk:Kghbln#Can_the_bot_be_made_to_accept_Gzip.3F

The pull request aims to add gzip support to the bot, as we would like our wiki farm to be indexed, but our server only accepts gzip connections for bandwidth reasons. 

Tagging @hexmode as per suggestion by Kghbln